### PR TITLE
Add WaveListener

### DIFF
--- a/genki_wave/asyncio_runner.py
+++ b/genki_wave/asyncio_runner.py
@@ -18,28 +18,12 @@ from genki_wave.data.organization import (
     DataPackage,
 )
 from genki_wave.data.writing import get_start_api_package
-from genki_wave.protocols import ProtocolAsyncio, ProtocolThread
+from genki_wave.protocols import ProtocolAsyncio, ProtocolThread, CommunicateCancel
 from genki_wave.utils import get_serial_port, get_or_create_event_loop
 
 logging.basicConfig(format="%(levelname).4s:%(asctime)s [%(filename)s:%(lineno)d] - %(message)s ")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-class CommunicateCancel:
-    """
-    Class that handles how to cancel asyncio loops with a button press and how to communicate it. Usually defined as
-    a global and sends messages to each part of the script
-    """
-
-    cancel = False
-
-    @staticmethod
-    def is_cancel(button_event: Union[ButtonEvent, DataPackage]) -> bool:
-        """Checks for a hard coded cancel event"""
-        if isinstance(button_event, DataPackage):
-            return False
-        return button_event.button_id == ButtonId.TOP and button_event.action == ButtonAction.EXTRALONG
 
 
 def prepare_protocol_as_bleak_callback_asyncio(protocol: ProtocolAsyncio) -> Callable:

--- a/genki_wave/asyncio_runner.py
+++ b/genki_wave/asyncio_runner.py
@@ -11,12 +11,6 @@ from serial_asyncio import open_serial_connection
 
 from genki_wave.callbacks import WaveCallback
 from genki_wave.constants import API_CHAR_UUID, BAUDRATE
-from genki_wave.data.organization import (
-    ButtonAction,
-    ButtonEvent,
-    ButtonId,
-    DataPackage,
-)
 from genki_wave.data.writing import get_start_api_package
 from genki_wave.protocols import ProtocolAsyncio, ProtocolThread, CommunicateCancel
 from genki_wave.utils import get_serial_port, get_or_create_event_loop

--- a/genki_wave/asyncio_runner.py
+++ b/genki_wave/asyncio_runner.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import signal
 import sys
 from functools import partial
 from typing import Union, List, Callable, Tuple
@@ -100,7 +99,6 @@ async def producer_bluetooth(
         The producer doesn't return a value, but the data gets added to the `protocol` that can be accessed from other
         parts of the program i.e. some `consumer`
     """
-    print(f"Connecting to wave at address {ble_address}")
     callback = bleak_callback(protocol)
     async with BleakClient(ble_address, disconnected_callback=make_disconnect_callback(comm)) as client:
         await client.start_notify(API_CHAR_UUID, callback)
@@ -160,22 +158,13 @@ async def consumer(
     while True:
         package = await protocol.queue.get()
 
-        if comm.is_cancel(package) or comm.cancel:
+        if comm.is_cancel(package):
             print("Got a cancel message. Exiting consumer loop...")
             comm.cancel = True
             break
 
         for callback in callbacks:
             callback(package)
-
-
-def make_sigint_handler(comm: CommunicateCancel):
-    """Create a signal handler to cancel an asyncio loop using signals."""
-
-    def handler(*args):
-        comm.cancel = True
-
-    return handler
 
 
 def _run_asyncio(
@@ -189,14 +178,15 @@ def _run_asyncio(
         protocol: An object that knows how to process the raw data sent from the Wave ring into a structured format
                   and passes it along between `producer` and `consumer`.
     """
-    # A singleton that sends messages about whether the data transfer has been canceled.
+    # TODO(robert): Catch a keyboard interrupt and gracefully shut down. Non-trivial to implement.
+
+    # A singleton that sends messages about whether the data transfer has been canceled. A slightly hacky fix
+    # to the problem of not handling keyboard interrupts
     comm = CommunicateCancel()
-    loop = get_or_create_event_loop()
-    loop.add_signal_handler(signal.SIGINT, make_sigint_handler(comm))
 
     # Note: The consumer and the producer send the data via the instance of `protocol`
-    tasks = asyncio.gather(producer(protocol, comm), consumer(protocol, comm, callbacks))
-    loop.run_until_complete(tasks)
+    tasks = asyncio.gather(*[producer(protocol, comm), consumer(protocol, comm, callbacks)])
+    get_or_create_event_loop().run_until_complete(tasks)
 
 
 def run_asyncio_bluetooth(callbacks: List[WaveCallback], ble_address) -> None:

--- a/genki_wave/protocols.py
+++ b/genki_wave/protocols.py
@@ -10,6 +10,7 @@ from serial.threaded import Packetizer
 
 from genki_wave.data.data_structures import QueueWithPop
 from genki_wave.data.organization import ButtonEvent, DataPackage, process_byte_data
+from genki_wave.utils import get_or_create_event_loop
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -69,6 +70,7 @@ class ProtocolAsyncio(ProtocolAbc, Packetizer):
 
     def __init__(self):
         super().__init__()
+        get_or_create_event_loop()
         self._queue = asyncio.Queue()
 
     async def data_received(self, data: Union[bytearray, bytes]) -> None:

--- a/genki_wave/protocols.py
+++ b/genki_wave/protocols.py
@@ -138,6 +138,7 @@ def prepare_protocol_as_bleak_callback_asyncio(protocol: ProtocolAsyncio) -> Cal
     async def _inner(sender: str, data: bytearray) -> None:
         # NOTE: `bleak` expects a function with this signature
         await protocol.data_received(data)
+
     return _inner
 
 

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -8,10 +8,11 @@ from serial.threaded import ReaderThread
 
 from genki_wave.constants import BAUDRATE
 from genki_wave.data.writing import get_start_api_package
-from genki_wave.protocols import ProtocolThread, ProtocolAsyncio, wave_task
+from genki_wave.protocols import ProtocolThread, ProtocolAsyncio, bluetooth_task, CommunicateCancel
+
 
 from genki_wave.utils import get_serial_port, get_or_create_event_loop
-from genki_wave.asyncio_runner import producer_bluetooth, CommunicateCancel, consumer
+from genki_wave.asyncio_runner import producer_bluetooth
 
 
 class ReaderThreadSerial(ReaderThread):
@@ -108,7 +109,7 @@ class WaveListener(threading.Thread):
 
     def run(self):
         self.comm = CommunicateCancel()
-        task = wave_task(self.ble_address, self.comm, self.callbacks)
+        task = bluetooth_task(self.ble_address, self.comm, self.callbacks)
         loop = get_or_create_event_loop()
         loop.run_until_complete(task)
 

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -8,7 +8,7 @@ from serial.threaded import ReaderThread
 
 from genki_wave.constants import BAUDRATE
 from genki_wave.data.writing import get_start_api_package
-from genki_wave.protocols import ProtocolThread, ProtocolAsyncio, bluetooth_task, CommunicateCancel
+from genki_wave.protocols import ProtocolThread, bluetooth_task, CommunicateCancel
 
 
 from genki_wave.utils import get_serial_port, get_or_create_event_loop

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -77,7 +77,6 @@ class ReaderThreadBluetooth(threading.Thread):
         """
         loop = get_or_create_event_loop()
         producer = producer_bluetooth(protocol, comm, ble_address)
-        # TODO(robert): Catch a keyboard interrupt and gracefully shut down. Non-trivial to implement.
         tasks = asyncio.gather(*[producer])
         loop.run_until_complete(tasks)
 

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -76,6 +76,7 @@ class ReaderThreadBluetooth(threading.Thread):
         """
         loop = get_or_create_event_loop()
         producer = producer_bluetooth(protocol, comm, ble_address)
+        # TODO(robert): Catch a keyboard interrupt and gracefully shut down. Non-trivial to implement.
         tasks = asyncio.gather(*[producer])
         loop.run_until_complete(tasks)
 

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -8,7 +8,8 @@ from serial.threaded import ReaderThread
 
 from genki_wave.constants import BAUDRATE
 from genki_wave.data.writing import get_start_api_package
-from genki_wave.protocols import ProtocolThread
+from genki_wave.protocols import ProtocolThread, ProtocolAsyncio
+
 from genki_wave.utils import get_serial_port, get_or_create_event_loop
 from genki_wave.asyncio_runner import producer_bluetooth, CommunicateCancel
 
@@ -98,3 +99,32 @@ class ReaderThreadBluetooth(threading.Thread):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Leave context: close port"""
         self.close()
+
+
+class WaveListener(threading.Thread):
+    def __init__(self, ble_address, callbacks):
+        self.ble_address = ble_address
+        self.callbacks = callbacks
+        super().__init__()
+
+    def run(self):
+        self.comm = CommunicateCancel()
+        protocol = ProtocolAsyncio()
+        tasks = asyncio.gather(
+            producer_bluetooth(protocol, self.comm, self.ble_address)
+            consumer(protocol, self.comm, self.callbacks)
+        )
+        loop = get_or_create_event_loop()
+        loop.run_until_complete(tasks)
+
+    def stop(self):
+        self.comm.cancel = True
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.stop()
+
+

--- a/genki_wave/threading_runner.py
+++ b/genki_wave/threading_runner.py
@@ -8,10 +8,10 @@ from serial.threaded import ReaderThread
 
 from genki_wave.constants import BAUDRATE
 from genki_wave.data.writing import get_start_api_package
-from genki_wave.protocols import ProtocolThread, ProtocolAsyncio
+from genki_wave.protocols import ProtocolThread, ProtocolAsyncio, wave_task
 
 from genki_wave.utils import get_serial_port, get_or_create_event_loop
-from genki_wave.asyncio_runner import producer_bluetooth, CommunicateCancel
+from genki_wave.asyncio_runner import producer_bluetooth, CommunicateCancel, consumer
 
 
 class ReaderThreadSerial(ReaderThread):
@@ -108,13 +108,9 @@ class WaveListener(threading.Thread):
 
     def run(self):
         self.comm = CommunicateCancel()
-        protocol = ProtocolAsyncio()
-        tasks = asyncio.gather(
-            producer_bluetooth(protocol, self.comm, self.ble_address)
-            consumer(protocol, self.comm, self.callbacks)
-        )
+        task = wave_task(self.ble_address, self.comm, self.callbacks)
         loop = get_or_create_event_loop()
-        loop.run_until_complete(tasks)
+        loop.run_until_complete(task)
 
     def stop(self):
         self.comm.cancel = True
@@ -125,5 +121,3 @@ class WaveListener(threading.Thread):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.stop()
-
-


### PR DESCRIPTION
WaveListener is loosely based on [the mouse Listener frpm pynput](https://pynput.readthedocs.io/en/latest/mouse.html#monitoring-the-mouse) - it can be used to pass callbacks to a separate thread that captures wave input.

Just adding this and leaving the ThreadingRunner in place is probably not ideal, it means we have multiple ways of doing things and probably makes the API confusing.