### PR TITLE
Add handling of raw gyro+accel payloads

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: '3.8'
           architecture: 'x64' # (x64 or x86)
-      - run: pip install black==20.8b1 flake8
+      - run: pip install black==22.3.0 flake8
       # Just checks all the files in the repo. Could be improved by only checking for files that were changed
       - run: black -l 120 --check .
       - name: flake8

--- a/genki_wave/callbacks.py
+++ b/genki_wave/callbacks.py
@@ -49,7 +49,7 @@ class ButtonAndDataPrint(WaveCallback):
         if self._last_time is None:
             self._last_time = data.timestamp_us
 
-        if (data.timestamp_us - self._last_time) > self._print_data_every_n_seconds * 10 ** 6:  # s to us
+        if (data.timestamp_us - self._last_time) > self._print_data_every_n_seconds * 10**6:  # s to us
             print(data)
             self._last_time = data.timestamp_us
 

--- a/genki_wave/data/__init__.py
+++ b/genki_wave/data/__init__.py
@@ -1,3 +1,3 @@
-from .organization import DataPackage, ButtonEvent  # noqa: F401
+from .organization import DataPackage, RawDataPackage, ButtonEvent  # noqa: F401
 from .enums import ButtonAction, ButtonId  # noqa: F401
 from .points import Euler3d, Point3d, Quaternion  # noqa: F401

--- a/genki_wave/data/enums.py
+++ b/genki_wave/data/enums.py
@@ -10,6 +10,7 @@ class PackageId(IntEnum):
     IDENTIFY = 6
     RECENTER = 7
     DISPLAY_FRAME = 8
+    RAW_DATA = 9
 
 
 class PackageType(IntEnum):

--- a/genki_wave/data/organization.py
+++ b/genki_wave/data/organization.py
@@ -27,7 +27,7 @@ class PackageMetadata:
 
     @classmethod
     def split_out_data_from_metadata(cls, raw_bytes: Union[bytearray, bytes]) -> Union[bytearray, bytes]:
-        return raw_bytes[struct.calcsize(cls._fmt):]
+        return raw_bytes[struct.calcsize(cls._fmt) :]
 
     def to_bytes(self) -> bytes:
         return struct.pack(self._fmt, self.type, self.id, self.payload_size)
@@ -104,8 +104,7 @@ class DataPackage:
 
 @dataclass(frozen=True)
 class RawDataPackage:
-    """Represents a package of raw data (just acc, gyro, and timestamp) sent from wave
-    """
+    """Represents a package of raw data (just acc, gyro, and timestamp) sent from wave"""
 
     _raw_len = 32
 

--- a/genki_wave/data/organization.py
+++ b/genki_wave/data/organization.py
@@ -94,7 +94,9 @@ class DataPackage:
     @classmethod
     def from_raw_gyro_accel_bytes(cls, data: Union[bytearray, bytes]) -> "DataPackage":
         # Explanation for the byte structure: https://docs.python.org/3/library/struct.html
-        assert len(data) == cls._raw_gyro_accel_len, f"Expected the raw gyro/accel data to have len={cls._raw_len}, got len={len(data)}"
+        if len(data) != cls._raw_gyro_accel_len:
+            raise ValueError(f"Expected the raw gyro/accel data to have len={cls._raw_len}, got len={len(data)}", data)
+
         # These parameters encode how to read the bytes from the stream
         return cls(
             gyro=Point3d(*unpack_from("<3f", data, 0)),

--- a/genki_wave/data/organization.py
+++ b/genki_wave/data/organization.py
@@ -27,7 +27,7 @@ class PackageMetadata:
 
     @classmethod
     def split_out_data_from_metadata(cls, raw_bytes: Union[bytearray, bytes]) -> Union[bytearray, bytes]:
-        return raw_bytes[struct.calcsize(cls._fmt) :]
+        return raw_bytes[struct.calcsize(cls._fmt):]
 
     def to_bytes(self) -> bytes:
         return struct.pack(self._fmt, self.type, self.id, self.payload_size)
@@ -225,11 +225,6 @@ def process_byte_data(raw_bytes: Union[bytearray, bytes]) -> Union[ButtonEvent, 
     elif q.is_raw_gyro_accel():
         # TODO: Might actually want to return a package variant instead of just zeroing out a bunch of fields here
         package = DataPackage.from_raw_gyro_accel_bytes(raw_bytes_data)
-
-        g, a, ts = package
-
-        print(f'{ts}, {g}, {a}')
-
     else:
         raise ValueError(f"Unknown value for q.id={q.id}")
 

--- a/genki_wave/data/points.py
+++ b/genki_wave/data/points.py
@@ -47,7 +47,7 @@ class Quaternion:
         return Quaternion(self.w, -self.x, -self.y, -self.z)
 
     def normalize(self):
-        norm = math.sqrt(sum([el ** 2 for el in [self.w, self.x, self.y, self.z]]))
+        norm = math.sqrt(sum([el**2 for el in [self.w, self.x, self.y, self.z]]))
         return Quaternion(self.w / norm, self.x / norm, self.y / norm, self.z / norm)
 
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -41,7 +41,7 @@ def test_quaternion_norm():
     q0 = Quaternion(1.0, 2.0, 3.0, -4.0).normalize()
     q1 = Quaternion(0.01, -0.556, -3.0, -0.002).normalize()
     for q in [q0, q1]:
-        assert sum([el ** 2 for el in [q.w, q.x, q.y, q.z]])
+        assert sum([el**2 for el in [q.w, q.x, q.y, q.z]])
 
 
 def test_quaternion_to_and_from_point():


### PR DESCRIPTION
Handle receipt of smaller payloads consisting of raw gyroscope + accelerometer payloads. This allows sampling data via serial at a higher rate. Requires updated firmware on the Wave ring.

[wave_v1-7-3.zip](https://github.com/genkiinstruments/genki-wave/files/8154518/wave_v1-7-3.zip)
 